### PR TITLE
[Feature] Add ability to get Records and Create Transactions with Puzzle Wallet

### DIFF
--- a/leo/build/main.aleo
+++ b/leo/build/main.aleo
@@ -25,6 +25,7 @@ record AuctionInvite:
     auction as auction.private;
     auctioneer as address.private;
     auction_id as field.private;
+    settings as privacy_settings.private;
 
 struct bid:
     amount as u64;
@@ -192,7 +193,7 @@ finalize publish_auction_data:
 function invite_to_auction:
     input r0 as AuctionTicket.record;
     input r1 as address.private;
-    cast r1 r0.auction r0.owner r0.auction_id into r2 as AuctionInvite.record;
+    cast r1 r0.auction r0.owner r0.auction_id r0.settings into r2 as AuctionInvite.record;
     output r2 as AuctionInvite.record;
     output r0 as AuctionTicket.record;
 

--- a/leo/build/program.json
+++ b/leo/build/program.json
@@ -1,14 +1,6 @@
 {
-  "program": "private_auction_test_2.aleo",
-  "version": "0.0.0",
-  "description": "",
-  "license": "MIT",
-  "dependencies": [
-    {
-      "name": "credits.aleo",
-      "location": "network",
-      "network": "testnet",
-      "path": null
-    }
-  ]
+    "program": "private_auction_test_2.aleo",
+    "version": "0.0.0",
+    "description": "",
+    "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@demox-labs/aleo-wallet-adapter-react": "^0.0.21",
         "@demox-labs/aleo-wallet-adapter-reactui": "^0.0.35",
         "@provablehq/sdk": "^0.8.8",
+        "@puzzlehq/sdk-core": "^1.0.3",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",

--- a/src/components/AuctionState.jsx
+++ b/src/components/AuctionState.jsx
@@ -1,6 +1,6 @@
 import React, {createContext, useContext, useEffect, useState} from "react";
 import { updatePublicState } from "../core/reducers/public.js";
-import { updateStateFromRecords } from "../core/reducers/demox.js";
+import { updateStateFromRecords } from "../core/reducers/private.js";
 import { parseImages } from "../core/reducers/images.js";
 import { PROGRAM_ID } from "../core/constants.js";
 import { useWallet } from "@demox-labs/aleo-wallet-adapter-react";
@@ -22,7 +22,7 @@ export const useAuctionState = () => {
 
 // Define the data structure
 export const AuctionState = ({ children }) => {
-    const { connected, requestRecords } = useWallet();
+    const { connected, requestRecords, wallet } = useWallet();
     const [auctionState, setAuctionState] = useState({
         auctions: {},
         bids: {},
@@ -210,8 +210,9 @@ export const AuctionState = ({ children }) => {
     };
 
     const updateAuctionStateFromRecords = (records) => {
+        const walletName = wallet?.adapter?.name;
         setAuctionState(prev => {
-            const privateState = updateStateFromRecords(prev, records);
+            const privateState = updateStateFromRecords(prev, records, walletName);
             const updatedState = {
                 ...prev,
                 ...privateState,
@@ -237,6 +238,7 @@ export const AuctionState = ({ children }) => {
         console.log("Updating private auction state...");
         try {
             const records = await requestRecords(PROGRAM_ID);
+            console.log("Fetched records:", records);
             updateAuctionStateFromRecords(records);
         } catch (error) {
             console.error("Error fetching records:", error);

--- a/src/components/WalletWrapper.jsx
+++ b/src/components/WalletWrapper.jsx
@@ -4,9 +4,6 @@ import { WalletModalProvider } from "@demox-labs/aleo-wallet-adapter-reactui";
 import { PROGRAM_ID } from "../core/constants.js";
 import {
     PuzzleWalletAdapter,
-    FoxWalletAdapter,
-    SoterWalletAdapter,
-    // configureConnectionForPuzzle,
 } from "aleo-adapters";
 import {
     DecryptPermission,
@@ -21,19 +18,19 @@ export const WalletWrapper = ({ children }) => {
     const wallets = useMemo(
         () => [
             new LeoWalletAdapter({
-                appName: "Leo Auction",
+                appName: "zkAuction",
             }),
             new PuzzleWalletAdapter({
                 programIdPermissions: {
-                    ["AleoMainnet"]: [
+                    [WalletAdapterNetwork.MainnetBeta]: [
                         PROGRAM_ID,
                     ],
-                    ["AleoTestnet"]: [
+                    [WalletAdapterNetwork.TestnetBeta]: [
                         PROGRAM_ID,
                     ],
                 },
-                appName: "Leo Auction",
-                appDescription: "A simple auction game",
+                appName: "zkAuction",
+                appDescription: "Private Auctions on Aleo",
             }),
         ],
         []

--- a/src/core/reducers/private.js
+++ b/src/core/reducers/private.js
@@ -1,12 +1,19 @@
 import { filterVisibility as f } from "../processing.js";
 
-function updateStateFromRecords(state, records) {
-    console.log("Existing state", state);
-    const auctionTickets = records.filter(record => record.recordName === "AuctionTicket");
-    const bidReceipts = records.filter(record => record.recordName === "BidReceipt");
-    const bidInvites = records.filter(record => record.recordName === "BidInvite");
-    const privateBids = records.filter(record => record.recordName === "PrivateBid");
-    const userAuctions = processAuctionTickets(state, auctionTickets, bidInvites);
+function updateStateFromRecords(state, records, walletName) {
+    let nameKey = "recordName"
+    let idKey = "id"
+    console.log("Wallet Name", walletName);
+    if (walletName === "Puzzle Wallet") {
+        nameKey = "name"
+        idKey = "_id"
+    }
+
+    const auctionTickets = records.filter(record => record[nameKey] === "AuctionTicket");
+    const bidReceipts = records.filter(record => record[nameKey] === "BidReceipt");
+    const bidInvites = records.filter(record => record[nameKey] === "BidInvite");
+    const privateBids = records.filter(record => record[nameKey] === "PrivateBid");
+    const userAuctions = processAuctionTickets(state, auctionTickets, idKey, nameKey);
 
     // Update auctions the user has created.
     const userAuctionIds = new Set(state.userAuctionIds);
@@ -17,11 +24,10 @@ function updateStateFromRecords(state, records) {
     }
     
     // Process bid invites to find auction IDs the user was invited to.
-    const [invitedAuctionIds, invitedAuctions] = processAuctionInvites(state, bidInvites);
+    const [invitedAuctionIds, invitedAuctions] = processAuctionInvites(state, bidInvites, idKey, nameKey);
 
     // Find user bid IDs from bid receipts.
-    const [bids, bidsOnUserAuctions, userBidIds] = processBidReceipts(state, bidReceipts);
-    console.log("User bids: ", bids);
+    const [bids, bidsOnUserAuctions, userBidIds] = processBidReceipts(state, bidReceipts, idKey, nameKey);
 
     // Create a merged auctions object that preserves existing state
     const mergedAuctions = { ...state.auctions };
@@ -99,7 +105,7 @@ function updateStateFromRecords(state, records) {
     return reducedState;
 }
 
-function processAuctionInvites (state, invites) {
+function processAuctionInvites (state, invites, idKey, nameKey) {
     const auctions = { ...state.auctions };
     console.log("Processing auction invites auctions: ", auctions);
     const invitedAuctionIds = new Set(state.invitedAuctionIds);
@@ -110,7 +116,7 @@ function processAuctionInvites (state, invites) {
                 invitedAuctionIds.add(auctionId);
             }
             if (!(auctionId in auctions)) {
-                auctions[auctionId] = newAuctionFromInvite(state, invite);
+                auctions[auctionId] = newAuctionFromInvite(state, invite, idKey, nameKey);
             }
         } catch (error) {
             console.error(error);
@@ -119,7 +125,7 @@ function processAuctionInvites (state, invites) {
     return [invitedAuctionIds, auctions];
 }
 
-function processBidReceipts (state, records) {
+function processBidReceipts (state, records, idKey, nameKey) {
     const userBidIds = new Set(state.userBidIds);
     const bidsOnUserAuctions = new Set(state.bidsOnUserAuctions);
     const bids = { ...state.bids };
@@ -135,7 +141,7 @@ function processBidReceipts (state, records) {
                 bidsOnUserAuctions.add(bidId);
             }
             if (!(bidId in bids)) {
-                bids[bidId] = newBidFromReceipt(state, record);
+                bids[bidId] = newBidFromReceipt(state, record, nameKey);
             }
         } catch (error) {
             console.error(error);
@@ -146,14 +152,16 @@ function processBidReceipts (state, records) {
 }
 
 // Process auction tickets from auctions.
-function processAuctionTickets (state, auctionTickets) {
+function processAuctionTickets (state, auctionTickets, idKey, nameKey) {
+    console.log(`While processing auction Tickets: idKey: ${idKey}, nameKey: ${nameKey}`);
     const auctions = { ...state.auctions };
+
     auctionTickets.forEach(record => {
         try {
             const auctionId = f(record.data.auction_id);
             if (!(auctionId in state)) {
-                auctions[auctionId] = newAuctionFromTicket(state, record);
-            } else if (state[auctionId].activeTicket?.id !== record.id) {
+                auctions[auctionId] = newAuctionFromTicket(state, record, idKey, nameKey);
+            } else if (state[auctionId].activeTicket?.[idKey] !== record[idKey]) {
                 auctions[auctionId] = {
                     ...state[auctionId],
                     activeTicket: record,
@@ -168,9 +176,13 @@ function processAuctionTickets (state, auctionTickets) {
 }
 
 // Set auctioneer record from AuctionTicket.
-function newAuctionFromTicket (state, record) {
+function newAuctionFromTicket (state, record, idKey, nameKey) {
+    console.log("Creating auction from ticket", record);
+    console.log("idKey, idKeyValue: ", idKey, record[idKey]);
+    console.log("Namekey, nameKeyValue ", nameKey, record[nameKey]);
+
     // Ensure the record is an AuctionTicket.
-    if (record.recordName !== "AuctionTicket") {
+    if (record[nameKey] !== "AuctionTicket") {
         throw new Error("Attempt to add new AuctionTicket record to state failed. Record is not an AuctionTicket");
     }
 
@@ -181,7 +193,7 @@ function newAuctionFromTicket (state, record) {
         auctionId: f(record.data.auction_id),
         auctioneer: record.owner,
         bidTypes: f(record.data.settings.bid_types_accepted),
-        recordId: record.id,
+        recordId: record[idKey],
         invited: false,
         itemId: f(record.data.auction.item.id),
         highestBid: 0,
@@ -196,9 +208,9 @@ function newAuctionFromTicket (state, record) {
     };
 }
 
-function newAuctionFromInvite(state, record) {
+function newAuctionFromInvite(state, record, walletName, idKey, nameKey) {
     // Ensure the record is an AuctionInvite.
-    if (record.recordName !== "AuctionInvite") {
+    if (record[nameKey] !== "AuctionInvite") {
         throw new Error("Attempt to add new AuctionInvite record to state failed. Record is not an AuctionInvite");
     }
 
@@ -209,7 +221,7 @@ function newAuctionFromInvite(state, record) {
         auctionId: f(record.data.auction_id),
         auctioneer: f(record.data.auctioneer),
         bidTypes: f(record.data?.settings?.bid_types_accepted),
-        recordId: record.id,
+        recordId: record[idKey],
         itemId: f(record.data?.item?.id),
         highestBid: 0,
         metadata: f(record.data?.item?.offchain_data),
@@ -223,9 +235,9 @@ function newAuctionFromInvite(state, record) {
     };
 }
 
-function newBidFromReceipt(state, record) {
+function newBidFromReceipt(state, record, nameKey) {
     // Ensure the record is a BidReceipt.
-    if (record.recordName !== "BidReceipt") {
+    if (record[nameKey] !== "BidReceipt") {
         throw new Error("Attempt to add new BidReceipt record to state failed. Record is not a BidReceipt");
     }
 

--- a/src/core/transaction.js
+++ b/src/core/transaction.js
@@ -1,0 +1,29 @@
+import { Transaction, WalletAdapterNetwork } from "@demox-labs/aleo-wallet-adapter-base";
+import {PROGRAM_ID} from "./constants.js";
+
+export async function createTransaction(params, execute, walletName) {
+    if (walletName === "Puzzle Wallet") {
+        // Create a transaction using the Puzzle Wallet SDK
+        const createEventResponse = await execute(params)
+        if (createEventResponse.error) {
+            console.log(`Error creating event: ${createEventResponse.error}`);
+        } else {
+            console.log(`Transaction created successfully: ${createEventResponse.eventId}`);
+        }
+    } else {
+        const transaction = Transaction.createTransaction(
+            params.publicKey,
+            WalletAdapterNetwork.TestnetBeta,
+            PROGRAM_ID,
+            params.functionName,
+            params.inputs,
+            params.fee,
+            params.feePrivate,
+        );
+
+        await execute(transaction);
+    }
+
+
+
+}

--- a/src/tabs/auctioneer/OpenAuctions.jsx
+++ b/src/tabs/auctioneer/OpenAuctions.jsx
@@ -5,11 +5,12 @@ import { useWallet } from '@demox-labs/aleo-wallet-adapter-react';
 import { useAuctionState } from '../../components/AuctionState.jsx';
 import { AuctionCard } from '../../components/AuctionCard.jsx';
 import { WalletMultiButton } from "@demox-labs/aleo-wallet-adapter-reactui";
+import {PROGRAM_ID} from "../../core/constants.js";
 
 const { Text } = Typography;
 
 export const OpenAuctions = () => {
-    const { connected, publicKey } = useWallet();
+    const { connected, publicKey, requestRecords, wallet } = useWallet();
     const { auctionState, updateAuctionStateOnConnect, updatePrivateAuctionState, updatePublicAuctionState } = useAuctionState();
     const [loading, setLoading] = useState(false);
     const [auctionData, setAuctionData] = useState({});
@@ -43,6 +44,9 @@ export const OpenAuctions = () => {
         setLoading(true);
         try {
             // Update both private and public state
+            let records = await requestRecords(PROGRAM_ID);
+
+            console.log(`Demox adapter with Puzzle Wallet data publicKey: ${publicKey}, connected: ${connected}, records: `, records);
             if (connected) {
                 await updatePrivateAuctionState();
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,7 +1463,7 @@
   resolved "https://registry.yarnpkg.com/@provablehq/wasm/-/wasm-0.8.8.tgz#b162e07e79e3d70f6fc5d7c2855115937b608dcf"
   integrity sha512-EOB36wv9bAb8ISDje8ambIyixtVgkgCycUg76vlx6O9OsCSpe+4TW6kZuqc5F398GRFeo46F0Ll4NtxiYELfpw==
 
-"@puzzlehq/sdk-core@1.0.3":
+"@puzzlehq/sdk-core@1.0.3", "@puzzlehq/sdk-core@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@puzzlehq/sdk-core/-/sdk-core-1.0.3.tgz#b4f24e6f773db3f2285ebfc8bb1eb5ee178f2a3f"
   integrity sha512-nYXunLzYmxNyTARH6lNKD0eW2DZp+XpKCPeJPLvDdIW2jy0rXdDo1L0/CTAF1r09yDjBdoibIvjzwCVljjWinA==


### PR DESCRIPTION
## Motivation

Previously the Auction Example only supported creating transactions and finding records with the Leo Wallet. This PR adds support for creating transactions and fetching records with the Puzzle Wallet.

## Changelog
* Adds handlers to private state fetching to scan for Puzzle specific record types
* Adds a single function for creating transactions which encapsulates Leo and Puzzle Wallet methods for creating transactions
* Updates all components which execute functions to use these new patterns.